### PR TITLE
vtable_structs: Add better vtable pseudocode

### DIFF
--- a/vtable_structs.py
+++ b/vtable_structs.py
@@ -132,7 +132,7 @@ class WaitBox:
 			WaitBox.shown = True
 
 	@staticmethod
-	def show(msg, buffertime = 0.1):
+	def show(msg, buffertime=0.1):
 		if msg == WaitBox.msg:
 			return
 
@@ -404,8 +404,8 @@ def create_structs(data):
 		classstruc = idaapi.get_struc(classstrucid)
 		for thisoffs, vfuncs in vtables.items():
 			thisoffs = abs(thisoffs)
-			postfix = f"{thisoffs:x}" if thisoffs != 0 else ""
-			structype = f"{classname}_vtbl{postfix}"
+			postfix = f"_{thisoffs:04X}" if thisoffs != 0 else ""
+			structype = f"{classname}{postfix}{idaapi.VTBL_SUFFIX}"
 			structype = idaapi.validate_name(structype, idaapi.VNT_TYPE, idaapi.SN_IDBENC)
 
 			vtablestrucid = add_struc_ex(structype)
@@ -446,14 +446,14 @@ def create_structs(data):
 					opinfo.ri.base = 0
 					opinfo.ri.tdelta = 0
 
-					serr = idaapi.add_struc_member(vtablestruc, targetname, offs, FF_PTR|idc.FF_0OFF|idc.FF_1OFF, opinfo, ctypes.sizeof(ea_t))
+					serr = idaapi.add_struc_member(vtablestruc, targetname, offs, FF_PTR|idc.FF_0OFF, opinfo, ctypes.sizeof(ea_t))
 					# Failed, so there was either an invalid name or a name collision
 					if serr == idaapi.STRUC_ERROR_MEMBER_NAME:
 						targetname = idaapi.validate_name(targetname, idaapi.VNT_IDENT, idaapi.SN_IDBENC)
-						serr = idaapi.add_struc_member(vtablestruc, targetname, offs, FF_PTR|idc.FF_0OFF|idc.FF_1OFF, opinfo, ctypes.sizeof(ea_t))
+						serr = idaapi.add_struc_member(vtablestruc, targetname, offs, FF_PTR|idc.FF_0OFF, opinfo, ctypes.sizeof(ea_t))
 						if serr == idaapi.STRUC_ERROR_MEMBER_NAME:
-							targetname = f"{targetname}_{offs:x}"
-							serr = idaapi.add_struc_member(vtablestruc, targetname, offs, FF_PTR|idc.FF_0OFF|idc.FF_1OFF, opinfo, ctypes.sizeof(ea_t))
+							targetname = f"{targetname}_{offs:X}"
+							serr = idaapi.add_struc_member(vtablestruc, targetname, offs, FF_PTR|idc.FF_0OFF, opinfo, ctypes.sizeof(ea_t))
 
 					if serr != idaapi.STRUC_ERROR_MEMBER_OK:
 						print(vtablestruc, vtablestrucid)
@@ -467,7 +467,7 @@ def create_structs(data):
 
 			vmember = idaapi.get_member(classstruc, thisoffs)
 			if not vmember:
-				if idaapi.add_struc_member(classstruc, f"vftbl{postfix}", thisoffs, idc.FF_DATA|FF_PTR, None, ctypes.sizeof(ea_t)) == idaapi.STRUC_ERROR_MEMBER_OK:
+				if idaapi.add_struc_member(classstruc, f"{idaapi.VTBL_MEMNAME}{postfix}", thisoffs, idc.FF_DATA | FF_PTR, None, ctypes.sizeof(ea_t)) == idaapi.STRUC_ERROR_MEMBER_OK:
 					global STRUCTS
 					STRUCTS += 1
 					tinfo = idaapi.tinfo_t()


### PR DESCRIPTION
This has been bothering me for a while so I began to research how to get this to work.

Basically, virtual function invocations, when viewed through pseudocode, currently have the following format:

```cpp
this->vtbl->SomeVirtualFunction(this)
```
This always bothered me since both the PDB plugin and IDAClang/file header parsing do not have that and the pseudocode properly writes the invocation:
```cpp
this->SomeVirtualFunction(this)
```

I did a lot of research and tried to parse the very difficult-to-follow PDB plugin code in the SDK to try and see if I could do this in vtable_structs.py.

Turns out, and I'm assuming that this is the case, that there is a "hack" for this where if you name the structures and structure members with the proper IDA-provided suffix and name (`VTBL_SUFFIX` and `VTBL_MEMNAME`), then IDA's engine will automatically ensure that the virtual table structure is listed as a virtual table in its type info, and the owning class/struct's type info will state that it contains a virtual table. This doesn't appear to work with virtual inheritance perhaps since I don't implement baseclass types, sadly. Might look into this in the future.

I discovered this by accident whilst trying to clean up the script's generation. Writing this PR took longer than the commit. Hurray!